### PR TITLE
refactor: Use composition rather than inheritance

### DIFF
--- a/pyplatformer/helpfun.py
+++ b/pyplatformer/helpfun.py
@@ -5,6 +5,7 @@ import pygame
 
 DEFAULT_IMAGE_PATH = Path("data", "img")
 
+
 class ImageWithRect(NamedTuple):
     image: pygame.Surface
     rect: pygame.Rect


### PR DESCRIPTION
Don't use multiple parent inheritance for class `Character`. Use composition create `CharacterLogic` instance as field of `Character` class. Move logic responsible for loading state from dict to `CharacterLogic` (because there is already `dump` method). Fix issues with types.