### PR TITLE
feat: Run pygame in main process

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,6 +26,8 @@ def single() -> None:
 @click.option("--host", default="localhost", type=str)
 def client(host: str, port: int) -> None:
     client = GameClient(server_addres=f"http://{host}:{port}/")
+    client.spawn_game_server_client()
+    client.initialize_screen()
     client.run()
 
 


### PR DESCRIPTION
When running 'game client' - run pygame as main process and websocket client as daeamon process. This way when user close windows websocket is also closed.